### PR TITLE
Pass path to SVGO optimize method

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ import SVGO from 'svgo';
 import compiler from 'vue-template-compiler';
 import transpile from 'vue-template-es2015-compiler';
 
-const optimizeSvg = (content, config) => new Promise((resolve, reject) => {
+const optimizeSvg = (content, config, path) => new Promise((resolve, reject) => {
   const svgo = new SVGO(config);
-  svgo.optimize(content).then((result) => {
+  svgo.optimize(content, { path }).then((result) => {
     if (result.error) return reject(result.error);
     return resolve(result.data);
   });
@@ -20,7 +20,7 @@ export default function (options) {
     name: 'vue-inline-svg',
     transform: (source, id) => {
       if (!filter(id)) return null;
-      return optimizeSvg(source, config).then((result) => {
+      return optimizeSvg(source, config, id).then((result) => {
         const compiled = compiler.compile(result, { preserveWhitespace: false });
         const transformed = transpile(`module.exports = { render: function () { ${compiled.render} } };`).replace('module.exports =', 'export default');
         return transformed;


### PR DESCRIPTION
In the vue-loader docs, there is an example of how to prefix SVG IDs using a function (the second example): https://vue-svg-loader.js.org/faq.html#how-to-prefix-id-attributes


Currently it's not possible to replicate that with this plugin, as no data is passed via the second parameter of svgo's optimize method. This PR changes a few lines to pass the path (id) that rollup provides the transform method, so makes that example code possible with this plugin too.

[Also see this node example in the svgo repo](https://github.com/svg/svgo/blob/master/examples/test.js#L85). 

Thanks for your work on this plugin!